### PR TITLE
Switch to glam

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["koalefant <mandarin.cake@gmail.com>"]
 edition = "2018"
 
 [features]
-serde_support = ["serde_derive", "serde"]
+default = []
+serde_support = ["serde_derive", "serde", "glam/serde", "slotmap/serde"]
 # hashing is disabled by default as it is not implemented for floating point types
 hash_support = []
 fixed_point = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["koalefant <mandarin.cake@gmail.com>"]
 edition = "2018"
 
 [features]
-default = []
 serde_support = ["serde_derive", "serde", "glam/serde", "slotmap/serde"]
 # hashing is disabled by default as it is not implemented for floating point types
 hash_support = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub fn realf(v: f32) -> Real {
     fixed_math::Fixed::from_f32(v)
 }
 
-/// this can be locally overriden, for example, to u    se fixed-point math or doubles
+/// this can be locally overriden, for example, to use fixed-point math or doubles
 #[cfg(feature = "fixed_point")]
 pub type Real2 = fixed_math::Fixed2;
 #[cfg(not(feature = "fixed_point"))]

--- a/src/world.rs
+++ b/src/world.rs
@@ -1055,8 +1055,8 @@ impl World {
                     b_velocity += p * b.inv_mass;
                     a_angular_velocity -= cross(r1, p) * a.inv_inertia;
                     b_angular_velocity += cross(r2, p) * b.inv_inertia;
-                    //assert!(a_velocity.x.is_finite() && a_velocity.y.is_finite());
-                    //assert!(b_velocity.x.is_finite() && b_velocity.y.is_finite());
+                    //assert!(a_velocity.x().is_finite() && a_velocity.y().is_finite());
+                    //assert!(b_velocity.x().is_finite() && b_velocity.y().is_finite());
                 }
             }
 
@@ -1110,7 +1110,7 @@ impl World {
                       }
                       */
                     if dpn != reali(0) || relative_velocity != Real2::zero() {
-                        //println!("dpn: {} relative velocity: {},{}", dpn, relative_velocity.x, relative_velocity.y);
+                        //println!("dpn: {} relative velocity: {},{}", dpn, relative_velocity.x(), relative_velocity.y());
                     }
 
                     // apply point normal impulse
@@ -1146,8 +1146,8 @@ impl World {
                     b_velocity += pt * b.inv_mass;
                     a_angular_velocity -= cross(point.r1, pt) * a.inv_inertia;
                     b_angular_velocity += cross(point.r2, pt) * b.inv_inertia;
-                    //assert!(a_velocity.x.is_finite() && a_velocity.y.is_finite());
-                    //assert!(b_velocity.x.is_finite() && b_velocity.y.is_finite());
+                    //assert!(a_velocity.x().is_finite() && a_velocity.y().is_finite());
+                    //assert!(b_velocity.x().is_finite() && b_velocity.y().is_finite());
                 }
                 let a = self.bodies.get_mut(a_k).expect("a_k");
                 a.velocity = a_velocity;
@@ -1167,9 +1167,9 @@ impl World {
     pub fn update_positions<D: Fn(Real2) -> Real>(&mut self, dt: Real, map_distance: &D) {
         for (a_k, a) in self.bodies.iter_mut() {
             if a.inv_mass != reali(0) {
-                //assert!(a.velocity.x.is_finite() && a.velocity.y.is_finite());
+                //assert!(a.velocity.x().is_finite() && a.velocity.y().is_finite());
                 let new_pos = a.pos + a.velocity * dt;
-                //assert!(new_pos.x.is_finite() && new_pos.y.is_finite());
+                //assert!(new_pos.x().is_finite() && new_pos.y().is_finite());
                 let max_penetration = a.max_penetration;
                 let (new_pos, _hit) = march_circle(
                     a.pos,


### PR DESCRIPTION
I don't believe the vek crate's high number of dependencies and gratuitous use of generics aligns with the goals of miniquad's niche in the community.

I understand, however, if you don't want to merge this PR. If that is the case, I will continue maintaining a glam version in a separate repository for as long as is feasible.

note: this commit also removes num-traits, since I believe it was added in only to help people benefit from vek's use of generics, and updates some usage of miniquad's API to fix some errors that prevented successful compilation of the example. To avoid more unsuccessful compilation in the future, we should probably pin the miniquad dependency more precisely.